### PR TITLE
feat: CLI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: pip install libpcap
+        run: sudo apt update && sudo apt install -y libpcap-dev
 
       - name: Clippy
         run: cargo clippy --all --all-features -- -D warnings
@@ -58,7 +58,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: pip install libpcap
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt update && sudo apt install -y libpcap-dev
 
       - name: Build project
         run: cargo build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install dependencies
+        run: pip install libpcap
+
       - name: Clippy
         run: cargo clippy --all --all-features -- -D warnings
 
@@ -53,6 +56,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: pip install libpcap
 
       - name: Build project
         run: cargo build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,15 +50,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
+        build: ['', --release]
         include:
-          - os: windows-latest
-            deps: choco install wireshark winpcap -y
           - os: macos-latest
             deps: brew install libpcap
           - os: ubuntu-latest
             deps: sudo apt update && sudo apt install -y libpcap-dev
-    name: ${{ matrix.os }}
+          - build: ''
+            profile: debug
+          - build: --release
+            profile: release
+    name: ${{ matrix.os }} - ${{ matrix.profile }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -68,7 +71,7 @@ jobs:
         run: ${{ matrix.deps }}
 
       - name: Build project
-        run: cargo build
+        run: cargo build ${{ matrix.build }}
 
       - name: Test project
         run: cargo test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
         include:
           - os: windows-latest
-            deps: winget install -e --id DaiyuuNobori.Win10Pcap
+            deps: choco install wireshark winpcap -y
           - os: macos-latest
             deps: brew install libpcap
           - os: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            deps: winget install -e --id DaiyuuNobori.Win10Pcap
+          - os: macos-latest
+            deps: brew install libpcap
+          - os: ubuntu-latest
+            deps: sudo apt update && sudo apt install -y libpcap-dev
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
@@ -58,8 +65,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt update && sudo apt install -y libpcap-dev
+        run: ${{ matrix.deps }}
 
       - name: Build project
         run: cargo build

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 /target
 Cargo.lock
+
+# PCAP files
+
+*.pcap

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ readme = "README.md"
 
 [dependencies]
 
-clap = { version = "3.2.5", features = ["derive"] }
-pcap = { version = "0.9.2", features = ["capture-stream"] }
+clap = { version = "3.2.17", features = ["derive"] }
+pcap = { version = "0.10.1", features = ["capture-stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ documentation = "https://github.com/Megalotron/Sniffer"
 readme = "README.md"
 
 [dependencies]
+
+clap = { version = "3.2.5", features = ["derive"] }
+pcap = { version = "0.9.2", features = ["capture-stream"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY . .
 
 # Install dependencies
-RUN apk add --no-cache musl-dev
+RUN apk add --no-cache musl-dev libpcap-dev
 
 # Update dependencies
 RUN cargo update

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /app
 # Copy sources
 COPY . .
 
+# Install dependencies
+RUN apk add --no-cache musl-dev
+
 # Update dependencies
 RUN cargo update
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,23 +3,19 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
 pub struct Args {
-    /// IP adress of the grpc server
+    /// URL of the grpc server to send the pcap data stream
     #[clap(short, long, value_parser)]
-    pub ip: Option<String>,
-
-    /// Port of the grpc server
-    #[clap(short, long, value_parser, default_value_t = 50051)]
-    pub port: u16,
+    pub url: Option<String>,
 
     /// Path to a pcap output file where to save captured packets
     #[clap(short, long, value_parser)]
     pub output: Option<String>,
 
-    /// If provided, the captured packets will be displayed in the shell
+    /// The captured packets will be displayed in the shell
     #[clap(short, long, value_parser, default_value_t = false)]
     pub verbose: bool,
 
-    /// If provided, the sniffer will use the provided interface instead of the default one
+    /// The provided network device will be used instead of the default one
     #[clap(short, long, value_parser)]
     pub device: Option<String>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,25 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(version, about, long_about = None)]
+pub struct Args {
+    /// IP adress of the grpc server
+    #[clap(short, long, value_parser)]
+    pub ip: Option<String>,
+
+    /// Port of the grpc server
+    #[clap(short, long, value_parser, default_value_t = 50051)]
+    pub port: u16,
+
+    /// Set pcap output file if you want to save the captured packets
+    #[clap(short, long, value_parser)]
+    pub output: Option<String>,
+
+    /// If provided, the captured packets will be displayed in the shell
+    #[clap(short, long, value_parser, default_value_t = false)]
+    pub verbose: bool,
+
+    /// If provided, the sniffer will use the provided interface
+    #[clap(short, long, value_parser)]
+    pub device: Option<String>,
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,7 +11,7 @@ pub struct Args {
     #[clap(short, long, value_parser, default_value_t = 50051)]
     pub port: u16,
 
-    /// Set pcap output file if you want to save the captured packets
+    /// Path to a pcap output file where to save captured packets
     #[clap(short, long, value_parser)]
     pub output: Option<String>,
 
@@ -19,7 +19,7 @@ pub struct Args {
     #[clap(short, long, value_parser, default_value_t = false)]
     pub verbose: bool,
 
-    /// If provided, the sniffer will use the provided interface
+    /// If provided, the sniffer will use the provided interface instead of the default one
     #[clap(short, long, value_parser)]
     pub device: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,35 @@
-fn main() {
-    println!("Hello, world!");
+mod args;
+
+use args::Args;
+use clap::Parser;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+
+    let dev = match args.device {
+        Some(dev) => pcap::Device::from(dev.as_str()),
+        None => pcap::Device::lookup()?,
+    };
+
+    println!("Using device \"{}\"", dev.name);
+
+    let mut cap = pcap::Capture::from_device(dev)?
+        .immediate_mode(true)
+        .open()?;
+
+    let mut savefile = match args.output {
+        Some(file) => Some(cap.savefile(file)?),
+        None => None,
+    };
+
+    while let Ok(packet) = cap.next() {
+        if args.verbose {
+            println!("received packet! {:?}", packet);
+        }
+        if savefile.is_some() {
+            savefile.as_mut().unwrap().write(&packet);
+        }
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let dev = match args.device {
         Some(dev) => pcap::Device::from(dev.as_str()),
-        None => pcap::Device::lookup()?,
+        None => pcap::Device::lookup()?.unwrap(),
     };
 
     println!("Using device \"{}\"", dev.name);
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         None => None,
     };
 
-    while let Ok(packet) = cap.next() {
+    while let Ok(packet) = cap.next_packet() {
         if args.verbose {
             println!("received packet! {:?}", packet);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     while let Ok(packet) = cap.next_packet() {
         if args.verbose {
-            println!("received packet! {:?}", packet);
+            println!("{:?}", packet);
         }
         if savefile.is_some() {
             savefile.as_mut().unwrap().write(&packet);


### PR DESCRIPTION
Related to [ENG-11/2.1](https://linear.app/megalotron/issue/ENG-11/21-implementation-dune-cli)
Signed-off-by: Martin Olivier <martin.olivier@live.fr>

## Description

This pull request provides a working sniffer and his CLI

### New dependencies

- [clap](https://docs.rs/clap/latest/clap) - used to parse and serialize command line arguments
- [pcap](https://docs.rs/pcap/latest/pcap) - used to collect the network traffic

### Features

CLI capabilities:
```
➜  Sniffer git:(feat/cli) ./target/debug/sniffer -h      
sniffer 0.1.0
The sniffer of Megalotron

USAGE:
    sniffer [OPTIONS]

OPTIONS:
    -d, --device <DEVICE>    The provided network device will be used instead of the default one
    -h, --help               Print help information
    -o, --output <OUTPUT>    Path to a pcap output file where to save captured packets
    -u, --url <URL>          URL of the grpc server to send the PCAP data stream
    -v, --verbose            The captured packets will be displayed in the shell
    -V, --version            Print version information
```

Sniffer output example:
```
➜  Sniffer git:(feat/cli) ./target/debug/sniffer -v -d en0 
Using device "en0"
Packet { header: PacketHeader { ts: 1661774064.923321, caplen: 173, len: 173 }, data: [1, 0, 94, 0, 0, 251, 162, 251, 197, 203, 46, 100, 8, 0, 69, 0, 0, 159, 118, 34, 0, 0, 255, 17, 174, 26, 172, 20, 10, 1, 224, 0, 0, 251, 20, 233, 20, 233, 0, 139, 241, 199, 0, 0, 0, 0, 0, 2, 0, 1, 0, 0, 0, 1, 2, 108, 98, 7, 95, 100, 110, 115, 45, 115, 100, 4, 95, 117, 100, 112, 5, 108, 111, 99, 97, 108, 0, 0, 12, 0, 1, 15, 95, 99, 111, 109, 112, 97, 110, 105, 111, 110, 45, 108, 105, 110, 107, 4, 95, 116, 99, 112, 192, 28, 0, 12, 0, 1, 192, 39, 0, 12, 0, 1, 0, 0, 17, 136, 0, 24, 21, 77, 97, 99, 66, 111, 111, 107, 32, 80, 114, 111, 32, 100, 101, 32, 77, 97, 114, 116, 105, 110, 192, 39, 0, 0, 41, 5, 160, 0, 0, 17, 148, 0, 18, 0, 4, 0, 14, 0, 149, 34, 168, 149, 128, 198, 216, 162, 251, 197, 203, 46, 100] }
Packet { header: PacketHeader { ts: 1661774064.923329, caplen: 193, len: 193 }, data: [51, 51, 0, 0, 0, 251, 162, 251, 197, 203, 46, 100, 134, 221, 96, 0, 4, 0, 0, 139, 17, 255, 254, 128, 0, 0, 0, 0, 0, 0, 160, 251, 197, 255, 254, 203, 46, 100, 255, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 251, 20, 233, 20, 233, 0, 139, 246, 46, 0, 0, 0, 0, 0, 2, 0, 1, 0, 0, 0, 1, 2, 108, 98, 7, 95, 100, 110, 115, 45, 115, 100, 4, 95, 117, 100, 112, 5, 108, 111, 99, 97, 108, 0, 0, 12, 0, 1, 15, 95, 99, 111, 109, 112, 97, 110, 105, 111, 110, 45, 108, 105, 110, 107, 4, 95, 116, 99, 112, 192, 28, 0, 12, 0, 1, 192, 39, 0, 12, 0, 1, 0, 0, 17, 136, 0, 24, 21, 77, 97, 99, 66, 111, 111, 107, 32, 80, 114, 111, 32, 100, 101, 32, 77, 97, 114, 116, 105, 110, 192, 39, 0, 0, 41, 5, 160, 0, 0, 17, 148, 0, 18, 0, 4, 0, 14, 0, 149, 34, 168, 149, 128, 198, 216, 162, 251, 197, 203, 46, 100] }
Packet { header: PacketHeader { ts: 1661774065.235168, caplen: 269, len: 269 }, data: [164, 131, 231, 179, 40, 28, 162, 251, 197, 203, 46, 100, 8, 0, 69, 40, 0, 255, 44, 7, 0, 0, 252, 6, 179, 37, 162, 159, 133, 234, 172, 20, 10, 6, 1, 187, 236, 67, 206, 10, 30, 225, 87, 87, 221, 248, 128, 24, 5, 20, 206, 192, 0, 0, 1, 1, 8, 10, 233, 115, 237, 178, 175, 205, 136, 181, 23, 3, 3, 0, 198, 87, 159, 155, 82, 35, 149, 158, 212, 110, 251, 192, 124, 214, 202, 135, 91, 84, 115, 227, 88, 24, 61, 101, 180, 232, 186, 112, 40, 160, 211, 94, 16, 129, 210, 167, 191, 28, 42, 106, 205, 181, 21, 88, 68, 116, 83, 220, 162, 32, 20, 26, 106, 86, 24, 242, 79, 207, 145, 82, 255, 186, 180, 0, 171, 19, 221, 79, 238, 250, 41, 217, 149, 192, 101, 254, 168, 243, 110, 79, 158, 121, 203, 197, 19, 150, 134, 207, 162, 234, 63, 181, 173, 18, 0, 156, 115, 255, 39, 58, 229, 16, 88, 137, 200, 205, 35, 124, 240, 116, 17, 149, 137, 122, 155, 116, 111, 110, 183, 88, 144, 134, 133, 226, 0, 224, 165, 1, 143, 248, 75, 222, 86, 187, 66, 130, 10, 194, 113, 46, 180, 207, 245, 213, 39, 83, 174, 121, 136, 229, 185, 107, 228, 15, 151, 174, 129, 122, 107, 224, 20, 180, 185, 161, 128, 67, 127, 234, 193, 194, 0, 171, 26, 48, 244, 200, 35, 209, 116, 10, 203, 143, 216, 40, 103, 97, 39, 200, 122, 90, 252, 52, 51, 250, 180, 141, 157, 208, 161] }
(...)
```

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [ ] I have tested this code
- [ ] I have added sufficient documentation in the code
- [X] I have added the right flag to this PR
